### PR TITLE
Fix/build qt 5.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ git submodule update --init --recursive
 Install qpropgen dependencies:
 
 ```
-pip3 install 3rdparty/qpropgen/requirements.txt`
+pip3 install -r 3rdparty/qpropgen/requirements.txt`
 ```
 
 Create a build dir:

--- a/src/ui/LogFormatWidget.cpp
+++ b/src/ui/LogFormatWidget.cpp
@@ -30,6 +30,7 @@
 #include "WidgetUtils.h"
 #include "ui_LogFormatWidget.h"
 
+#include <QAction>
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QPushButton>


### PR DESCRIPTION
- add missing QAction include : 
QMake version 3.1
Using Qt version 5.12.2

- Readme: add missing pip3 arg